### PR TITLE
Added dontInitialize flag

### DIFF
--- a/Adafruit_SHTC3.cpp
+++ b/Adafruit_SHTC3.cpp
@@ -50,17 +50,18 @@ Adafruit_SHTC3::~Adafruit_SHTC3(void) {
  * Initialises the I2C bus, and assigns the I2C address to us.
  *
  * @param theWire   The I2C bus to use, defaults to &Wire
+ * @param dontInitialize Whether initialize the given TwoWire object.
  *
  * @return True if initialisation was successful, otherwise False.
  */
-bool Adafruit_SHTC3::begin(TwoWire *theWire) {
+bool Adafruit_SHTC3::begin(TwoWire *theWire, const bool dontInitialize) {
   if (i2c_dev) {
     delete i2c_dev; // remove old interface
   }
 
   i2c_dev = new Adafruit_I2CDevice(SHTC3_DEFAULT_ADDR, theWire);
 
-  if (!i2c_dev->begin()) {
+  if (!i2c_dev->begin(true, dontInitialize)) {
     return false;
   }
 

--- a/Adafruit_SHTC3.h
+++ b/Adafruit_SHTC3.h
@@ -97,7 +97,7 @@ public:
   Adafruit_SHTC3(void);
   ~Adafruit_SHTC3(void);
 
-  bool begin(TwoWire *theWire = &Wire);
+  bool begin(TwoWire *theWire = &Wire, const bool dontInitialize = false);
   uint16_t readID(void);
   void reset(void);
   void sleep(bool sleepmode);


### PR DESCRIPTION
Hi,

this pr adds a flag to avoid the initialization of the TwoWire object.
This is required when there are many I2C devices, and, therefore, the I2C (TwoWire)
initialization should be performed only once.

This pr requires the similar change made in https://github.com/adafruit/Adafruit_BusIO/pull/57

This pr is fully backward compatible.
