### PR TITLE
Fixes error on initialization when SHTC3 its sleep

### DIFF
--- a/Adafruit_SHTC3.cpp
+++ b/Adafruit_SHTC3.cpp
@@ -66,8 +66,8 @@ bool Adafruit_SHTC3::begin(TwoWire *theWire) {
     return false;
   }
 
-  reset();
   sleep(false);
+  reset();
 
   // read the ID
   if ((readID() & 0x083F) != 0x807) {


### PR DESCRIPTION
This changes fixes a problem that i found when a microcontroller resets after a meassure request (particulary on an esp32-s3), after reading the datasheet of the SHTC3 it indicates that "When the sensor is in sleep mode, it requires the following
wake-up command before ANY further communication", so when the sensor it sleep it can´t receive the "soft-reset" command, also on the soft-reset part of the datasheet it states: " If the system is IN ITS IDLE state (i.e. if no measurement is in progress) the soft reset command can be sent to SHTC3", clearly if the SHTC3 it´s on sleep mode it can´t receive the soft-reset command so the SHTC3 doesn´t respond the ACK on the fisrt byte of the soft-reset command (i checked this with a logic analizer).
The only change its on the begin methos on wish i inverted the order of the Sleep and reset methods, after this the SHTC3 initializes correctly.
Ref.: https://sensirion.com/media/documents/643F9C8E/63A5A436/Datasheet_SHTC3.pdf
Page 6 section 5.2 Power-Up, Sleep, Wakeup and page 8 section 5.7 Soft Reset
